### PR TITLE
update database.gradle

### DIFF
--- a/database.gradle
+++ b/database.gradle
@@ -18,7 +18,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'org.owasp:dependency-check-gradle:6.0.2'
+        classpath 'org.owasp:dependency-check-gradle:6.1.6'
         classpath 'mysql:mysql-connector-java:8.0.21'
     }
 }


### PR DESCRIPTION
Gradle build is hanging without failure, DefaultFileLockManager acquiring and releasing lock on daemon addresses registry.When I ran with the --debug flag, I got this output regarding the DeafultFileLockManager acquiring and releasing a daemon lock, but this has been unhelpful. Here is the last bit of the gradle debug log that I see.
![image](https://user-images.githubusercontent.com/31351525/119918886-d8056380-bf9b-11eb-9354-a7f995a92b6b.png)
When update dependency-check-gradle from 6.0.2 to 6.1.6, I solve this bug.