### PR TITLE
Use supercronic as crontab mechanism which is specifically designed to run in c…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,18 @@
+FROM debian:stable-slim@sha256:db5d246d767a1daf54aecdf0e888925e78174b2051bc571337e1ae72aa722b5d AS supercronic
+
+ENV SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.1.12/supercronic-linux-amd64 \
+    SUPERCRONIC=supercronic-linux-amd64 \
+    SUPERCRONIC_SHA1SUM=048b95b48b708983effb2e5c935a1ef8483d9e3e
+
+RUN apt-get update; apt-get install -y curl \
+ && curl -fsSLO "$SUPERCRONIC_URL" \
+ && echo "${SUPERCRONIC_SHA1SUM}  ${SUPERCRONIC}" | sha1sum -c - \
+ && chmod +x "$SUPERCRONIC" \
+ && mv "$SUPERCRONIC" "/usr/local/bin/${SUPERCRONIC}" \
+ && ln -s "/usr/local/bin/${SUPERCRONIC}" /usr/local/bin/supercronic
+
+
+
 FROM mysql:5.7.31
 
 LABEL maintainer="Stefan Neuhaus <stefan@stefanneuhaus.org>"
@@ -22,12 +37,12 @@ RUN set -ex && \
     apt-get purge -y --auto-remove; \
     rm -rf /var/lib/apt; \
     /dependencycheck/gradlew --no-daemon wrapper; \
-    echo "0 * * * *  /dependencycheck/update.sh" >/etc/cron.d/dependencycheck-database-update; \
-    crontab /etc/cron.d/dependencycheck-database-update; \
+    echo "0 * * * *  /dependencycheck/update.sh" > /dependencycheck/dependencycheck-database-update; \
     cat /dev/urandom | tr -dc _A-Za-z0-9 | head -c 32 >/dependencycheck/dc-update.pwd; \
     chmod 400 /dependencycheck/dc-update.pwd; \
     chown --recursive mysql:mysql /dependencycheck
 
+COPY --from=supercronic /usr/local/bin/supercronic /usr/local/bin/
 COPY database.gradle update.sh /dependencycheck/
 COPY initialize_schema.sql /docker-entrypoint-initdb.d/
 COPY initialize_security.sql /docker-entrypoint-initdb.d/

--- a/README.md
+++ b/README.md
@@ -83,3 +83,4 @@ you should just throw away the old server container and start a new one from a c
 ## Notes
 
 - Clients do not require internet access in general. There are only a few analyzers that do require it. Please refer to the [OWASP DependencyCheck documentation](https://jeremylong.github.io/DependencyCheck/data/index.html#Downloading_Additional_Information) for further information.
+- Running the image as non-root: use the mysql(999:999) user provided by the base image (mysql).

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-cron
+supercronic /dependencycheck/dependencycheck-database-update &
 /usr/local/bin/docker-entrypoint.sh --user=root


### PR DESCRIPTION
…ontainers.

When running the image as non-root you cannot use cron as it cannot start as non root user. Supercronic allows you to start is as a different user.