### PR TITLE
fix: bump version to 5.2

### DIFF
--- a/initialize_schema.sql
+++ b/initialize_schema.sql
@@ -241,4 +241,4 @@ END //
 DELIMITER ;
 
 
-INSERT INTO properties(id, value) VALUES ('version', '5.1');
+INSERT INTO properties(id, value) VALUES ('version', '5.2');


### PR DESCRIPTION
Hi, I checked DependencyCheck, the latest version now is 6.3.2. So I suggest we can set new tag (6.3.2) if this pr has been merged.