### PR TITLE
Bump Dependency Check to 9.0.6 so synchronization works again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-20230109-slim AS supercronic
+FROM debian:bullseye-slim AS supercronic
 
 ENV SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.2.1/supercronic-linux-amd64 \
     SUPERCRONIC=supercronic-linux-amd64 \
@@ -13,7 +13,7 @@ RUN apt-get update; apt-get install -y curl \
 
 
 
-FROM mysql:5.7.41-debian
+FROM mysql:8.0.35-debian
 
 LABEL maintainer="Stefan Neuhaus <stefan@stefanneuhaus.org>"
 
@@ -26,7 +26,6 @@ ENV MYSQL_DATABASE=dependencycheck \
 WORKDIR /dependencycheck
 
 RUN set -ex && \
-    echo "deb http://http.debian.net/debian buster-backports main" >/etc/apt/sources.list.d/buster-backports.list; \
     apt-get update; \
     mkdir -p /usr/share/man/man1; \
     apt-get install -y openjdk-11-jre-headless procps cron; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ COPY overlays/docker-entrypoint-initdb.d /docker-entrypoint-initdb.d/
 
 RUN set -ex && \
     /dependencycheck/gradlew wrapper; \
-    echo "0 * * * *  /dependencycheck/update.sh" > /dependencycheck/database-update-schedule; \
+    echo "0/2 * * * *  /dependencycheck/update.sh" > /dependencycheck/database-update-schedule; \
     chown --recursive mysql:mysql /dependencycheck
 
 COPY --from=supercronic /usr/local/bin/supercronic /usr/local/bin/

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ docker run -p 3306:3306 stefanneuhaus/dependencycheck-central-mysql
 ### Analysis clients
 
 All kinds of analysis clients are supported: Gradle, Maven, Ant, Jenkins, CLI. Apply the following changes to your build file:
-- add buildscript dependency for `mysql:mysql-connector-java:8.0.30`
+- add buildscript dependency for `com.mysql:mysql-connector-j:8.2.0`
 - disable database updates triggered by your project: `autoUpdate = false`
 - add database connection parameters: `data { ... }`
 
@@ -35,7 +35,7 @@ buildscript {
     }
     dependencies {
         classpath 'org.owasp:dependency-check-gradle:8.0.0'
-        classpath 'mysql:mysql-connector-java:8.0.30'
+        classpath 'com.mysql:mysql-connector-j:8.2.0'
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ In order to start the Database Server simply run
 docker run -p 3306:3306 stefanneuhaus/dependencycheck-central-mysql
 ```
 
+#### NVD API key
+
+To have a faster synchronization proces, you should apply for an NVD API key.
+Get one [at the NVD website](https://nvd.nist.gov/developers/request-an-api-key).
+If you have one, start your Docker container with `-e NVD_API_KEY=<Your API key here>`.
+
 ### Analysis clients
 
 All kinds of analysis clients are supported: Gradle, Maven, Ant, Jenkins, CLI. Apply the following changes to your build file:
@@ -34,7 +40,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'org.owasp:dependency-check-gradle:8.0.0'
+        classpath 'org.owasp:dependency-check-gradle:9.0.6'
         classpath 'com.mysql:mysql-connector-j:8.2.0'
     }
 }

--- a/overlays/dependencycheck/build.gradle
+++ b/overlays/dependencycheck/build.gradle
@@ -18,7 +18,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'org.owasp:dependency-check-gradle:8.0.0'
+        classpath 'org.owasp:dependency-check-gradle:9.0.6'
         classpath 'com.mysql:mysql-connector-j:8.2.0'
     }
 }
@@ -26,12 +26,15 @@ buildscript {
 apply plugin: 'org.owasp.dependencycheck'
 
 dependencyCheck {
-    cveValidForHours = 0
     data {
         connectionString = "jdbc:mysql://localhost:3306/dependencycheck?useSSL=false&allowPublicKeyRetrieval=true"
         driver = "com.mysql.cj.jdbc.Driver"
         username = "dc-update"
         password = "<DC_UPDATE_PASSWORD>"
+    }
+    nvd {
+        validForHours = 0
+        apiKey = System.getenv("NVD_API_KEY") ?: ""
     }
 }
 

--- a/overlays/dependencycheck/build.gradle
+++ b/overlays/dependencycheck/build.gradle
@@ -19,7 +19,7 @@ buildscript {
     }
     dependencies {
         classpath 'org.owasp:dependency-check-gradle:8.0.0'
-        classpath 'mysql:mysql-connector-java:8.0.31'
+        classpath 'com.mysql:mysql-connector-j:8.2.0'
     }
 }
 

--- a/overlays/wrapper.sh
+++ b/overlays/wrapper.sh
@@ -1,4 +1,12 @@
 #!/bin/sh
 
+if [ -z "${NVD_API_KEY}" ]; then
+  echo "--------------------------------------------------------------------------------"
+  echo "  Detected that environment variable NVD_API_KEY was not set."
+  echo "  Please provide an NVD API key! Updates will be very slow without it."
+  echo "  Visit https://nvd.nist.gov/developers/request-an-api-key to get one."
+  echo "--------------------------------------------------------------------------------"
+fi
+
 supercronic /dependencycheck/database-update-schedule &
 /usr/local/bin/docker-entrypoint.sh --user=root

--- a/test/project_uptodate/build.gradle
+++ b/test/project_uptodate/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'org.owasp:dependency-check-gradle:8.0.0'
+        classpath 'org.owasp:dependency-check-gradle:9.0.6'
         classpath 'com.mysql:mysql-connector-j:8.2.0'
     }
 }

--- a/test/project_uptodate/build.gradle
+++ b/test/project_uptodate/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
     dependencies {
         classpath 'org.owasp:dependency-check-gradle:8.0.0'
-        classpath 'mysql:mysql-connector-java:8.0.31'
+        classpath 'com.mysql:mysql-connector-j:8.2.0'
     }
 }
 


### PR DESCRIPTION
- Bumped MySQL Docker image to 8.0.31 (according to [this](https://www.mysql.com/support/eol-notice.html) users are encouraged to upgrade to MySQL 8.0).
- Bumped the MySQL JDBC driver to `com.mysql:mysql-connector-j:8.2.0`.
- Bumped OWASP Dependency Check to 9.0.6. This makes synchronization work again.

I currently experience a lot of `SQLException: Incorrect string value: '\xEF\xBF\xBDboa...' for column 'p_shortDescription' at row 1` in my `/dependencycheck/update.log` file. I also read that that NVD is deprecating their old RSS feeds. To use their newer API you should use the 9.x versions of OWASP Dependency Check. And with the 9.x version I don't have a synchronization issue anymore, so I consider it fixed 😀
