### PR TITLE
Bump dependencycheck plugin to 12.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,10 @@ Example (Gradle):
 buildscript {
     repositories {
         mavenCentral()
+        gradlePluginPortal()
     }
     dependencies {
-        classpath 'org.owasp:dependency-check-gradle:10.0.2'
+        classpath 'org.owasp:dependency-check-gradle:12.1.0'
         classpath 'com.mysql:mysql-connector-j:8.4.0'
     }
 }
@@ -73,6 +74,7 @@ Updates of the Database are triggered every 2 minutes. The initial update can ta
 
 |             Client |   Server |
 |-------------------:|---------:|
+|         `>= 6.3.0` | `12.1.2` |
 |         `>= 6.3.0` | `10.0.2` |
 |         `>= 6.3.0` |  `9.0.8` |
 |         `>= 6.3.0` |  `8.0.0` |

--- a/overlays/dependencycheck/build.gradle
+++ b/overlays/dependencycheck/build.gradle
@@ -16,9 +16,10 @@
 buildscript {
     repositories {
         mavenCentral()
+        gradlePluginPortal()
     }
     dependencies {
-        classpath 'org.owasp:dependency-check-gradle:10.0.2'
+        classpath 'org.owasp:dependency-check-gradle:12.1.0'
         classpath 'com.mysql:mysql-connector-j:8.4.0'
     }
 }

--- a/test/project_uptodate/build.gradle
+++ b/test/project_uptodate/build.gradle
@@ -1,9 +1,10 @@
 buildscript {
     repositories {
         mavenCentral()
+        gradlePluginPortal()
     }
     dependencies {
-        classpath 'org.owasp:dependency-check-gradle:10.0.2'
+        classpath 'org.owasp:dependency-check-gradle:12.1.0'
         classpath 'com.mysql:mysql-connector-j:8.4.0'
     }
 }


### PR DESCRIPTION
Because of https://github.com/dependency-check/DependencyCheck/issues/7463 prior versions do not work with the NVD API anymore and will fill up the logs.

During initial synchronization I did hit https://github.com/dependency-check/DependencyCheck/issues/7418. I did not find a way around it apart from entering the container and manually killing the `java` process 🙁